### PR TITLE
Update GolangCI to v1.52.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ COMMON_GO_ARGS=-race
 GIT_COMMIT=$(shell script/create-version-files.sh)
 GIT_RELEASE=$(shell script/get-git-release.sh)
 GIT_PREVIOUS_RELEASE=$(shell script/get-git-previous-release.sh)
-GOLANGCI_VERSION=v1.50.1
+GOLANGCI_VERSION=v1.52.2
 LINKER_TNF_RELEASE_FLAGS=-X github.com/test-network-function/autodiscover/autodiscover.GitCommit=${GIT_COMMIT}
 LINKER_TNF_RELEASE_FLAGS+= -X github.com/test-network-function/autodiscover/autodiscover.GitRelease=${GIT_RELEASE}
 LINKER_TNF_RELEASE_FLAGS+= -X github.com/test-network-function/autodiscover/autodiscover.GitPreviousRelease=${GIT_PREVIOUS_RELEASE}

--- a/autodiscover/autodiscover.go
+++ b/autodiscover/autodiscover.go
@@ -183,7 +183,6 @@ func getOpenshiftVersion(oClient clientconfigv1.ConfigV1Interface) (ver string, 
 		switch {
 		case kerrors.IsForbidden(err), kerrors.IsNotFound(err):
 			logrus.Infof("OpenShift Version not found (must be logged in to cluster as admin): %v", err)
-			err = nil
 		}
 	}
 	if clusterOperator != nil {


### PR DESCRIPTION
Related to: https://github.com/test-network-function/cnf-certification-test/pull/1058